### PR TITLE
PoC faster LSMs with static calls/keys: ask for feedbacks

### DIFF
--- a/security/security.c
+++ b/security/security.c
@@ -10,7 +10,6 @@
 
 #define pr_fmt(fmt) "LSM: " fmt
 
-#ifndef DEBUG_NO_IMPORT
 #include <linux/bpf.h>
 #include <linux/capability.h>
 #include <linux/dcache.h>
@@ -32,7 +31,6 @@
 #include <linux/static_call.h>
 #include <linux/static_key.h>
 #include <linux/printk.h>
-#endif
 
 #define MAX_LSM_EVM_XATTR	2
 
@@ -485,7 +483,6 @@ noinline RET LSM_FUNC_DEFAULT(NAME)(__VA_ARGS__)	\
 	DEFINE_STATIC_CALL(HOOK_STATIC_CALL(NAME, NUM), LSM_FUNC_DEFAULT(NAME));\
 	DEFINE_STATIC_KEY_FALSE(HOOK_STATIC_CHECK(NAME, NUM));
 
-
 #define LSM_HOOK(RET, DEFAULT, NAME, ...)		\
 	CREATE_STATIC(NAME, 1)				\
 	CREATE_STATIC(NAME, 2)				\
@@ -508,7 +505,6 @@ noinline RET LSM_FUNC_DEFAULT(NAME)(__VA_ARGS__)	\
 		TRY_TO_ADD(HOOK, FUNC, 3)		\
 		printk(KERN_ERR "No slot remaining to add LSM hook for " #HOOK "\n"); \
 	} while(0)
-
 
 /**
  * security_add_hooks - Add a modules hooks to the hook lists.
@@ -764,7 +760,6 @@ static void __init lsm_early_task(struct task_struct *task)
 		static_call_cond(HOOK_STATIC_CALL(FUNC, 3))(__VA_ARGS__);	\
 	} while (0)
 
-
 // #define call_void_hook(FUNC, ...)				\
 	do {							\
 		struct security_hook_list *P;			\
@@ -772,7 +767,6 @@ static void __init lsm_early_task(struct task_struct *task)
 		hlist_for_each_entry(P, &security_hook_heads.FUNC, list) \
 			P->hook.FUNC(__VA_ARGS__);		\
 	} while (0)
-
 
 #define call_int_hook(FUNC, IRC, ...) ({			\
 	int RC = IRC;						\

--- a/security/security.c
+++ b/security/security.c
@@ -526,8 +526,6 @@ void __init security_add_hooks(struct security_hook_list *hooks, int count,
 	for (i = 0; i < count; i++) {
 		hooks[i].lsm = lsm;
 		hlist_add_tail_rcu(&hooks[i].list, hooks[i].head);
-		// if (&security_hook_heads.file_permission == hooks[i].head)
-		// 	ADD_STATIC_HOOK(file_permission, hooks[i].hook.file_permission);
 
 		#define LSM_HOOK(RET, DEFAULT, NAME, ...)			\
 		if (&security_hook_heads.NAME == hooks[i].head)			\
@@ -761,15 +759,20 @@ static void __init lsm_early_task(struct task_struct *task)
 
 #define call_void_hook(FUNC, ...)				\
 	do {							\
-		static_call_cond(HOOK_STATIC_CALL(FUNC, 1))(__VA_ARGS__);	\ 
-		static_call_cond(HOOK_STATIC_CALL(FUNC, 2))(__VA_ARGS__);	\ 
-		static_call_cond(HOOK_STATIC_CALL(FUNC, 3))(__VA_ARGS__);	\ 
+		static_call_cond(HOOK_STATIC_CALL(FUNC, 1))(__VA_ARGS__);	\
+		static_call_cond(HOOK_STATIC_CALL(FUNC, 2))(__VA_ARGS__);	\
+		static_call_cond(HOOK_STATIC_CALL(FUNC, 3))(__VA_ARGS__);	\
 	} while (0)
 
-		// struct security_hook_list *P;			\
-		// 						\
-		// hlist_for_each_entry(P, &security_hook_heads.FUNC, list) \
-		// 	P->hook.FUNC(__VA_ARGS__);		\
+
+// #define call_void_hook(FUNC, ...)				\
+	do {							\
+		struct security_hook_list *P;			\
+								\
+		hlist_for_each_entry(P, &security_hook_heads.FUNC, list) \
+			P->hook.FUNC(__VA_ARGS__);		\
+	} while (0)
+
 
 #define call_int_hook(FUNC, IRC, ...) ({			\
 	int RC = IRC;						\
@@ -780,13 +783,20 @@ static void __init lsm_early_task(struct task_struct *task)
 	} while (0);						\
 	RC;							\
 })
-		// struct security_hook_list *P;			\
-		// 						\
-		// hlist_for_each_entry(P, &security_hook_heads.FUNC, list) { \
-		// 	RC = P->hook.FUNC(__VA_ARGS__);		\
-		// 	if (RC != 0)				\
-		// 		break;				\
-		// }						\
+
+// #define call_int_hook(FUNC, IRC, ...) ({			\
+	int RC = IRC;						\
+	do {							\
+		struct security_hook_list *P;			\
+								\
+		hlist_for_each_entry(P, &security_hook_heads.FUNC, list) { \
+			RC = P->hook.FUNC(__VA_ARGS__);		\
+			if (RC != 0)				\
+				break;				\
+		}						\
+	} while (0);						\
+	RC;							\
+})
 
 /* Security operations */
 


### PR DESCRIPTION
This patch is to ask for comments and suggestions.

This uses static keys and static calls to get rid of the indirect calls for the LSMs.
For each LSM hook, there are 3 "slots" (the number can be changed). A slot corresponds to a static key, which indicates if this slot is used or not, and a static call, which would contain the function to call if the slot is used. 
For example, for the hook `file_permission`, we will define: 
```
DEFINE_STATIC_CALL(static_call_file_permission_1, LSM_FUNC_DEFAULT(file_permission));
DEFINE_STATIC_KEY_FALSE(static_check_file_permission_1);
DEFINE_STATIC_CALL(static_call_file_permission_2, LSM_FUNC_DEFAULT(file_permission));
DEFINE_STATIC_KEY_FALSE(static_check_file_permission_2);
DEFINE_STATIC_CALL(static_call_file_permission_3, LSM_FUNC_DEFAULT(file_permission));
DEFINE_STATIC_KEY_FALSE(static_check_file_permission_3);
```
Although the static key API provides an [array definition](https://github.com/PaulRenauld/linux/blob/poc-static-calls/include/linux/jump_label.h#L26), it is not the case for static calls, and it would be non-trivial to add it (code [here](https://github.com/PaulRenauld/linux/blob/poc-static-calls/include/linux/static_call.h)). It makes it hard to provide a cleaner structure and we cannot use a for-loop to access the slots. Instead, we use a macro `FOR_EACH_HOOK_SLOT(M, ...)` which will expand. 

We also need to keep in mind that not all functions use `call_int_hook`/`call_void_hook`. Some access the list directly. Therefore we still need to add the hooks to the linked list. Right now, we cannot have more LSMs on a specific hook than 3. If we want to remove the limit, we could add all the LSM to the hook list, but keep a pointer to the 3rd element. Then, in `call_int_hook`/`call_void_hook`, keep the iteration on the list, but start at index 3. This way, the first three LSMs are optimized, and the other have the same cost than before.